### PR TITLE
Fix bundler gem install error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install gems
         run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install --jobs 4 --retry 3
 
       - name: Build site with Jekyll

--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install gems
         run: |
-          gem install bundler
+          gem install bundler -v 2.4.22
           bundle install --jobs 4 --retry 3
 
       - name: Build site with Jekyll


### PR DESCRIPTION
- When installing the bundler gem the following error was being thrown: "The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22."